### PR TITLE
Allow shortname to start with numbers

### DIFF
--- a/RepoCleanup/Functions/SharedFunctionSnippets.cs
+++ b/RepoCleanup/Functions/SharedFunctionSnippets.cs
@@ -133,7 +133,7 @@ namespace RepoCleanup.Functions
                 isValid = IsValidOrgShortName(shortName);
                 if (!isValid)
                 {
-                    Console.WriteLine("Invalid name. Letters a-z and character '-' are permitted. Username must start with a letter and end with a letter or number.");
+                    Console.WriteLine("Invalid name. The name must consist of letters or/and digits.");
                 }
             }
 
@@ -142,7 +142,7 @@ namespace RepoCleanup.Functions
 
         private static bool IsValidOrgShortName(string shortName)
         {
-            return Regex.IsMatch(shortName, "^[a-z]+[a-z0-9]$");
+            return Regex.IsMatch(shortName, "^[a-z0-9]+$");
         }
 
         public static void ConfirmWithExit(string confirmMessage, string exitMessage)


### PR DESCRIPTION
## Description
Allow the short name of an org to start with digits. 

## Related Issue(s)
- https://github.com/Altinn/altinn-support-private/issues/2034

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
