### PR TITLE
update hostname for local env to correct value

### DIFF
--- a/RepoCleanup/Program.cs
+++ b/RepoCleanup/Program.cs
@@ -89,7 +89,7 @@ namespace RepoCleanup
                     url = "https://altinn.studio/repos/api/v1/";
                     break;
                 case Application.Models.Environment.Local:
-                    url = "http://altinn3.no/repos/api/v1/";
+                    url = "http://studio.localhost/repos/api/v1/";
                     break;
                 default:
                     SelectEnvironment();
@@ -116,7 +116,7 @@ namespace RepoCleanup
                 case Application.Models.Environment.Production:
                     return "https://altinn.studio/repos/";
                 case Application.Models.Environment.Local:
-                    return "http://altinn3.no/repos/";
+                    return "http://studio.localhost/repos/";
             }
             
             return string.Empty;
@@ -167,7 +167,7 @@ namespace RepoCleanup
                     url = "https://altinn.studio/repos/user/settings/applications";
                     break;
                 case Application.Models.Environment.Local:
-                    url = "http://altinn3.no/repos/user/settings/applications";
+                    url = "http://studio.localhost/repos/user/settings/applications";
                     break;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We no longer use `altinn3.no` as hostname for local development. This has been changed to `studio.localhost`. Updated all instances of `altinn3.no` in RepoCleanup tool.

## Verification
- [x] **Your** code builds clean without any errors or warnings
