### PR TITLE
Update dependency to a version that should not break tests

### DIFF
--- a/AppsMonitoring/test/Altinn.Apps.Monitoring.Tests/Altinn.Apps.Monitoring.Tests.csproj
+++ b/AppsMonitoring/test/Altinn.Apps.Monitoring.Tests/Altinn.Apps.Monitoring.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.4.0" />
-    <PackageReference Include="WireMock.Net" Version="1.8.0" />
+    <PackageReference Include="WireMock.Net" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Version 1.8.0 of WireMock.Net lead to failing tests. This aims to fix that. 

## Related Issue(s)
Related to https://github.com/Altinn/team-core-private/issues/225

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
