### PR TITLE
AppsMonitoring: Use version tagging for fluxcd/flux2/action

### DIFF
--- a/.github/workflows/apps-monitoring-deploy.yml
+++ b/.github/workflows/apps-monitoring-deploy.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: flux install
-        uses: fluxcd/flux2/action@8d9cbe7693cde4200b70e9ae4749cecb47d3f445 # No tag
+        uses: fluxcd/flux2/action@b73c7f7191086ca7629840e680e71873349787f8 # v2.6.1
         with:
           version: '2.5.1'
 

--- a/.github/workflows/apps-monitoring-promote.yml
+++ b/.github/workflows/apps-monitoring-promote.yml
@@ -50,7 +50,7 @@ jobs:
             }
 
       - name: flux install
-        uses: fluxcd/flux2/action@8d9cbe7693cde4200b70e9ae4749cecb47d3f445 # No tag
+        uses: fluxcd/flux2/action@b73c7f7191086ca7629840e680e71873349787f8 # v2.6.1
         with:
           version: '2.5.1'
 


### PR DESCRIPTION
## Description
Using version tags allows Renovate's PRs to be more descriptive on whether new features are major, minor, or patches.

This action is currently getting "patched" by Renovate when commits are pushed to `main` of [fluxcd/flux2](https://github.com/fluxcd/flux2), e.g. #164.

## Related Issue(s)
N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
