### PR TITLE
Bump AppsMonitoring packages, only deploy on workload_dispatch

### DIFF
--- a/.github/workflows/apps-monitoring-deploy.yml
+++ b/.github/workflows/apps-monitoring-deploy.yml
@@ -2,11 +2,6 @@ name: Apps.Monitoring deploy
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - AppsMonitoring/**
-    branches:
-      - main
 
 jobs:
   deploy:

--- a/AppsMonitoring/.config/dotnet-tools.json
+++ b/AppsMonitoring/.config/dotnet-tools.json
@@ -3,9 +3,9 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.30.6",
+      "version": "1.0.2",
       "commands": [
-        "dotnet-csharpier"
+        "csharpier"
       ],
       "rollForward": false
     }

--- a/AppsMonitoring/.csharpierignore
+++ b/AppsMonitoring/.csharpierignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+.git/
+*.xml
+*.csproj
+*.props
+*.targets

--- a/AppsMonitoring/Directory.Build.props
+++ b/AppsMonitoring/Directory.Build.props
@@ -17,7 +17,7 @@
     <Using Include="NodaTime" />
     <Using Include="NodaTime.Extensions" />
 
-    <PackageReference Include="CSharpier.MsBuild" Version="0.30.6">
+    <PackageReference Include="CSharpier.MsBuild" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/AppsMonitoring/src/Altinn.Apps.Monitoring/Altinn.Apps.Monitoring.csproj
+++ b/AppsMonitoring/src/Altinn.Apps.Monitoring/Altinn.Apps.Monitoring.csproj
@@ -15,21 +15,21 @@
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
 
-    <PackageReference Include="System.IO.Hashing" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
 
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.4.0" />
-    <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.6.0" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="NodaTime" Version="3.2.2" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
 
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0-beta.3" />
-    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.6.0" />
     <PackageReference Include="Azure.ResourceManager.OperationalInsights" Version="1.3.0" />
 

--- a/AppsMonitoring/test/Altinn.Apps.Monitoring.Tests/Altinn.Apps.Monitoring.Tests.csproj
+++ b/AppsMonitoring/test/Altinn.Apps.Monitoring.Tests/Altinn.Apps.Monitoring.Tests.csproj
@@ -20,18 +20,18 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.v3" Version="2.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Meziantou.Extensions.Logging.Xunit.v3" Version="1.1.3" />
-    <PackageReference Include="Verify.XunitV3" Version="28.16.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.4.0" />
-    <PackageReference Include="WireMock.Net" Version="1.8.1" />
+    <PackageReference Include="Meziantou.Extensions.Logging.Xunit.v3" Version="1.1.5" />
+    <PackageReference Include="Verify.XunitV3" Version="30.3.1" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.6.0" />
+    <PackageReference Include="WireMock.Net" Version="1.8.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
* Bumps dotnet packages and makes necessary changes
* Changes deploy workflow so that we don't deploy automatically on push to main (we have to approve deployments anyway, even for at24)

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
