### PR TITLE
Explicit System.Text.Json reference in AppsMonitoring to avoid outdated reference

### DIFF
--- a/AppsMonitoring/Directory.Build.props
+++ b/AppsMonitoring/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true' OR '$(CI)' == 'true'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/AppsMonitoring/src/Altinn.Apps.Monitoring/Altinn.Apps.Monitoring.csproj
+++ b/AppsMonitoring/src/Altinn.Apps.Monitoring/Altinn.Apps.Monitoring.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="NodaTime" Version="3.2.2" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
+    <!-- <PackageReference Include="System.Text.Json" Version="9.0.6" /> -->
 
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />

--- a/AppsMonitoring/src/Altinn.Apps.Monitoring/Altinn.Apps.Monitoring.csproj
+++ b/AppsMonitoring/src/Altinn.Apps.Monitoring/Altinn.Apps.Monitoring.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="NodaTime" Version="3.2.2" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-    <!-- <PackageReference Include="System.Text.Json" Version="9.0.6" /> -->
+    <PackageReference Include="System.Text.Json" Version="9.0.6" />
 
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />

--- a/AppsMonitoring/src/Altinn.Apps.Monitoring/Dockerfile
+++ b/AppsMonitoring/src/Altinn.Apps.Monitoring/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0-noble@sha256:4f50505b5344e9d8a76805d71bb4ba76da6b01656e17a66a8ce1e4c4dfaaec12 AS build
 WORKDIR /source
+ENV CI=true
 
 COPY ./Directory.Build.props ./
 COPY ./.csharpierrc.yaml ./


### PR DESCRIPTION
## Description
* Explicit System.Text.Json reference with never version as deploy failed due to emitted warning (https://github.com/Altinn/altinn-tools/actions/runs/15581361297)
* Don't ignore nuget audit warnings in CI

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
