### PR TITLE
AppsMonitoring - randomize seed db file name to avoid races during tests

### DIFF
--- a/AppsMonitoring/src/Altinn.Apps.Monitoring/Application/Db/Seeder.cs
+++ b/AppsMonitoring/src/Altinn.Apps.Monitoring/Application/Db/Seeder.cs
@@ -24,7 +24,7 @@ internal sealed class Seeder(
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         using var activity = _telemetry.Activities.StartActivity("Seeder.Run");
-        var dbFilePath = Path.Combine(Path.GetTempPath(), "seed.db");
+        var dbFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".db");
         try
         {
             await using var handle = await _locking.AcquireLock(DistributedLockName.DbSeeder, cancellationToken);


### PR DESCRIPTION
## Description
Tests are parallelized, so not sure why I've not seen this fail more often. But with this change the filename is randomized so that multiple fixtures can run in parallel 

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
