### PR TITLE
Make team-apps owners of apps-monitoring workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-*                 @altinn/team-core
-AppsMonitoring/** @altinn/team-apps
-RepoCleanup/**    @altinn/team-studio
+*                                  @altinn/team-core
+AppsMonitoring/**                  @altinn/team-apps
+.github/workflows/apps-monitoring* @altinn/team-apps
+RepoCleanup/**                     @altinn/team-studio


### PR DESCRIPTION
## Description
Add a line for .github/workflows/apps-monitoring* and assign team-apps as owners of it

## Related Issue(s)
-N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
