### PR TITLE
Update RepoCleanup dependencies

### DIFF
--- a/RepoCleanup/RepoCleanup.csproj
+++ b/RepoCleanup/RepoCleanup.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
This pull request updates the `Microsoft.Extensions` dependencies of the `RepoCleanup` solution to version `9.0.8`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- Relevant automated test: Not relevant
- All tests run green: There are no tests in the `RepoCleanup` solution.