### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/assign-issues-to-projects.yml
+++ b/.github/workflows/assign-issues-to-projects.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   add-to-project:
     name: Add issue to Team Platform project
+    permissions:
+      issues: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-tools/security/code-scanning/4](https://github.com/Altinn/altinn-tools/security/code-scanning/4)

To fix the problem, add a minimal `permissions` block to the job (or at the workflow root) explicitly listing only the permissions required. In this case, the workflow automates adding issues to a GitHub Project, for which `issues: write` is typically required, and possibly `contents: read`. Place the `permissions` section under the `add-to-project` job (line 10) or at the root level if you want to apply it to all jobs. Since only one job is present, add it under the job for clarity and least impact. No additional methods or dependencies are needed; just a YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
