### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/apps-monitoring-pr-build.yml
+++ b/.github/workflows/apps-monitoring-pr-build.yml
@@ -1,4 +1,6 @@
 name: Apps.Monitoring PR build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-tools/security/code-scanning/5](https://github.com/Altinn/altinn-tools/security/code-scanning/5)

To address this issue, add a `permissions` block to the workflow configuration file to explicitly restrict the GITHUB_TOKEN permissions to the minimum necessary. Since the shown workflow uses `actions/checkout` to read code but does not perform any repository or PR write operations, the most restrictive suitable permissions would be `contents: read`. The `permissions` block should be placed at the root level of the workflow file (right after the `name:` but before `on:`) so that it applies to all jobs by default. This change will not affect the existing workflow functionality, as the job only needs to read repository contents.

No new imports or definitions are needed; the fix consists simply of adding the `permissions:` block at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
