### PR TITLE
fix: Allow digits in org shortname after first character, not just at the end

### DIFF
--- a/RepoCleanup/Functions/SharedFunctionSnippets.cs
+++ b/RepoCleanup/Functions/SharedFunctionSnippets.cs
@@ -133,7 +133,7 @@ namespace RepoCleanup.Functions
                 isValid = IsValidOrgShortName(shortName);
                 if (!isValid)
                 {
-                    Console.WriteLine("Invalid name. Letters a-z and character '-' are permitted. Username must start with a letter and end with a letter or number.");
+                    Console.WriteLine("Invalid short name. Letters a-z and numbers are permitted. Name must start with a letter.");
                 }
             }
 
@@ -142,7 +142,7 @@ namespace RepoCleanup.Functions
 
         private static bool IsValidOrgShortName(string shortName)
         {
-            return Regex.IsMatch(shortName, "^[a-z]+[a-z0-9]$");
+            return Regex.IsMatch(shortName, "^[a-z][a-z0-9]+$");
         }
 
         public static void ConfirmWithExit(string confirmMessage, string exitMessage)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We ran into an issue where Trondheim Kommune `t5001` could not be created as an org, because the regex for short name was too strict.

Previously, the regex allowed starting with letters, and the last character could be a number or letter.
Now, it is allowed to start with letters, and the rest of the characters can be numbers or letters.

Also updated the error message. Removed the part about allowing `-`, since that was never the case.

Tested by creating an org in the dev environment:
<img width="805" height="600" alt="bilde" src="https://github.com/user-attachments/assets/5f1e75cd-2ae7-48cc-a43f-603ba26c0cdb" />


## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
