### PR TITLE
add resources-repo when creating org

### DIFF
--- a/RepoCleanup/Functions/SetupNewServiceOwnerFunction.cs
+++ b/RepoCleanup/Functions/SetupNewServiceOwnerFunction.cs
@@ -45,8 +45,9 @@ namespace RepoCleanup.Functions
             // Create default repositories
             var isDatamodelRepoCreated = await CreateRepoWithPrefix(giteaService, org, "datamodels");
             var isContentRepoCreated = await CreateRepoWithPrefix(giteaService, org, "content");
+            var isResourceRepoCreated = await CreateRepoWithPrefix(giteaService, org, "resources");
 
-            if (isDatamodelRepoCreated && isContentRepoCreated)
+            if (isDatamodelRepoCreated && isContentRepoCreated && isResourceRepoCreated)
             {
                 Console.WriteLine("Done setting up new service owner in Gitea!");
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Include `{org}-resources` as a default repo to be created when org is created.

## Related Issue(s)
https://digdir.slack.com/archives/C0760NPT2BE/p1776240281232329

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
