### PR TITLE
Include resource/acceslist teams in org creation

### DIFF
--- a/RepoCleanup/Application/CommandHandlers/CreateDefaultTeamsCommandHandler.cs
+++ b/RepoCleanup/Application/CommandHandlers/CreateDefaultTeamsCommandHandler.cs
@@ -25,6 +25,10 @@ namespace RepoCleanup.Application.CommandHandlers
             teams.Add(TeamOption.GetCreateTeamOption("Admin-TT02", "Members can administer published apps in TT02", false, Permission.read));
             teams.Add(TeamOption.GetCreateTeamOption("Devs", "All application developers", true, Permission.write));
             teams.Add(TeamOption.GetCreateTeamOption("Datamodels", "Team for those who can work on an organizations shared data models.", false, Permission.write));
+            teams.Add(TeamOption.GetCreateTeamOption("Resources-Publish-TT02", "Members can deploy resources to TT02", false, Permission.read));
+            teams.Add(TeamOption.GetCreateTeamOption("Resources-Publish-PROD", "Members can deploy resources to PROD", false, Permission.read));
+            teams.Add(TeamOption.GetCreateTeamOption("AccessLists-TT02", "Members can deploy resources to TT02", false, Permission.read));
+            teams.Add(TeamOption.GetCreateTeamOption("AccessLists-PROD", "Members can deploy resources to PROD", false, Permission.read));
 
             foreach (CreateTeamOption team in teams)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the resources and access list publish teams when creating a new org. Teams do not have repo write access.

## Related Issue(s)
https://digdir.slack.com/archives/C0760NPT2BE/p1776240281232329

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
