### PR TITLE
add resources as standard team and configure repo access for teams

### DIFF
--- a/RepoCleanup/Application/CommandHandlers/CreateDefaultTeamsCommandHandler.cs
+++ b/RepoCleanup/Application/CommandHandlers/CreateDefaultTeamsCommandHandler.cs
@@ -25,6 +25,7 @@ namespace RepoCleanup.Application.CommandHandlers
             teams.Add(TeamOption.GetCreateTeamOption("Admin-TT02", "Members can administer published apps in TT02", false, Permission.read));
             teams.Add(TeamOption.GetCreateTeamOption("Devs", "All application developers", true, Permission.write));
             teams.Add(TeamOption.GetCreateTeamOption("Datamodels", "Team for those who can work on an organizations shared data models.", false, Permission.write));
+            teams.Add(TeamOption.GetCreateTeamOption("Resources", "Team for those who can work on an organizations authorization resources.", false, Permission.write));
             teams.Add(TeamOption.GetCreateTeamOption("Resources-Publish-TT02", "Members can deploy resources to TT02", false, Permission.read));
             teams.Add(TeamOption.GetCreateTeamOption("Resources-Publish-PROD", "Members can deploy resources to PROD", false, Permission.read));
             teams.Add(TeamOption.GetCreateTeamOption("AccessLists-TT02", "Members can deploy resources to TT02", false, Permission.read));

--- a/RepoCleanup/Functions/SetupNewServiceOwnerFunction.cs
+++ b/RepoCleanup/Functions/SetupNewServiceOwnerFunction.cs
@@ -49,8 +49,33 @@ namespace RepoCleanup.Functions
 
             if (isDatamodelRepoCreated && isContentRepoCreated && isResourceRepoCreated)
             {
-                Console.WriteLine("Done setting up new service owner in Gitea!");
+                Console.WriteLine($"Added all default repositories for {org.Fullname}");
             }
+
+            // Ensure that datamodels and resources teams have write access to the datamodels and resources repos respectively
+            var addTeamToRepoCommandHandler = new AddTeamToRepoCommandHandler(giteaService);
+            int datamodelsTeamAddedToDatamodelsRepo = await addTeamToRepoCommandHandler.Handle(new AddTeamToRepoCommand([org.Username], "datamodels", true, "Datamodels"));
+            int resourcesTeamAddedToResourcesRepo = await addTeamToRepoCommandHandler.Handle(new AddTeamToRepoCommand([org.Username], "resources", true, "Resources"));
+
+            if (datamodelsTeamAddedToDatamodelsRepo == 0)
+            {
+                Console.WriteLine($"Could not add Datamodels team to datamodels repo for {org.Fullname}");
+            }
+            else
+            {
+                Console.WriteLine($"Added Datamodels team to datamodels repo for {org.Fullname}");
+            }
+
+            if (resourcesTeamAddedToResourcesRepo == 0)
+            {
+                Console.WriteLine($"Could not add Resources team to resources repo for {org.Fullname}");
+            }
+            else
+            {
+                Console.WriteLine($"Added Resources team to resources repo for {org.Fullname}");
+            }
+
+            Console.WriteLine("Done setting up new service owner in Gitea!");
         }
 
         private static async Task<bool> CreateRepoWithPrefix(GiteaService giteaService, Organisation org, string repoName)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a `Resources` team that should have access to the `{org}-resources` repo.
Ensure the `Resources` team is set up with access to the repo.
Also ensure the `Datamodels` team is set up with access to the `datamodels`-repo.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
